### PR TITLE
S3 list cache improvements

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,17 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+## [1.2.0] - 2020-02-11
+### Added
+- Persistent S3 path caching in Redis
+
+### Removed
+- S3 communicator full_cache_seed option, `full_cache_seed: true` behavior now default
+
+## [1.1.0] - 2019-02-04
+### Added
+- verify_block_checksum feature to cleaner
+
+
+## [1.0.1] - 2019-01-22
+- Initial public release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.1
+FROM ruby:2.5
 
 # Ensure the locale is set to UTF-8 to avoid encoding errors on non-ASCII paths
 RUN echo 'locales locales/locales_to_be_generated multiselect en_US.UTF-8 UTF-8' | debconf-set-selections && \

--- a/Docs/Configuration.md
+++ b/Docs/Configuration.md
@@ -99,6 +99,23 @@ communicator:
 	# Note that the backups, cleaner, and restores all use different IAM users and keys for security.
         access_key_id: [Access Key]
         secret_access_key: [Secret Key]
+
+    # Cache: A list of the bucket contents is downloaded and cached locally for speed/cost.
+    cache_config:
+      # Cache type: One of:
+      #   memory: List is stored in process memory and seeded each run (default)
+      #   redis: List is stored in a Redis (redis.io) instance, list is seeded as the cache expires and is shared between runs
+      type: 'memory'
+      # TTL: Cache expiration in seconds, currently only applies to 'redis' cache type
+      ttl: 2592000
+
+      # Redis config: Arguments passed directly through to the Redis-rb gem, only applies to 'redis' cache type
+      # https://github.com/redis/redis-rb#getting-started
+      # Note that the REDIS_URL environment variable is also supported.
+      redis_config:
+        host: 127.0.0.1
+        port: 6379
+
 ```
 
 ### Encryption Block
@@ -273,7 +290,8 @@ encryption: [Encryption block, see above]
 cleaner:
   # Minimum block age: Minimum age in seconds before a unused block will be removed
   # This is to prevent the cleaner from removing newly uploaded blocks before a manifest was written
-  min_block_age: 86400
+  # NOTE: When using persistent S3 cache beckends like Redis this value must be >= the cache TTL to avoid race conditions and broken backups.
+  min_block_age: 2592000
 
   # Minimum manifest age: Minimum age in seconds before a manifest will be removed
   min_manifest_age: 31536000

--- a/Docs/Configuration.md
+++ b/Docs/Configuration.md
@@ -91,11 +91,6 @@ communicator:
     # Glacier not currently supported due to it being asynchronous
     storage_class: 'ONEZONE_IA'
 
-    # Full cache seed (boolean): When true the communicator will list the contents of the bucket on startup and cache the results
-    # For backups where the [number of target files] > ([files in bucket] / 1000) this is faster and more cost-effective than individual lists.
-    # For small backups this will be slower and may cost more.
-    full_cache_seed: true
-
     # S3 client config: Config passed directly to Aws::S3::Client.new(): https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Client.html#initialize-instance_method
     s3_client_config:
       region: [AWS Region]
@@ -204,7 +199,6 @@ communicator:
   backend_config:
     bucket: 'mybucket'
     storage_class: 'ONEZONE_IA'
-    full_cache_seed: true
     s3_client_config:
       region: us-east-2
       credentials:

--- a/app/Gemfile
+++ b/app/Gemfile
@@ -5,6 +5,7 @@ gem 'bindata', '~> 2.4'
 gem 'concurrent-ruby', '~> 1.1'
 gem 'openssl', '~> 2.1'
 gem 'powerpack', '~> 0.1'
+gem 'redis', '~> 4.1'
 gem 'yaml_extend', '~> 0.2'
 gem 'zlib', '~> 1.0'
 

--- a/app/Gemfile
+++ b/app/Gemfile
@@ -10,6 +10,6 @@ gem 'zlib', '~> 1.0'
 
 group 'development' do
   gem 'rspec', '~> 3.8'
-  gem 'rubocop', '~> 0.61'
+  gem 'rubocop', '~> 0.63.0'
   gem 'simplecov', '~> 0.16'
 end

--- a/app/lib/backup_engine/communicator.rb
+++ b/app/lib/backup_engine/communicator.rb
@@ -6,12 +6,12 @@ require_relative 'communicator_backend/encoder.rb'
 
 module BackupEngine
   class Communicator
-    def initialize(type:, backend_config:)
+    def initialize(type:, backend_config:, logger:)
       @backend = case type
                  when 'filesystem'
                    CommunicatorBackend::Filesystem.new(backend_config.symbolize_keys)
                  when 's3'
-                   CommunicatorBackend::S3.new(backend_config.symbolize_keys)
+                   CommunicatorBackend::S3.new(backend_config.symbolize_keys.merge(logger: logger))
                  else
                    raise("Unknown communicator type #{type}")
                  end

--- a/app/lib/backup_engine/communicator_backend/s3.rb
+++ b/app/lib/backup_engine/communicator_backend/s3.rb
@@ -21,7 +21,7 @@ module BackupEngine
         end
         @s3 = Aws::S3::Client.new(s3_client_config.symbolize_keys)
 
-        # Always perform a full cache seed to simplify cache handling, changed in [TODO: VERSION]
+        # Always perform a full cache seed to simplify cache handling, changed in v1.2.0
         # https://github.com/TJNII/BackwoodsBackup/issues/8
         # full_cache_seed argument is left for reverse compatibility in configs
         raise(S3CommunicatorError, 'full_cache_seed option has been deprecated, see https://github.com/TJNII/BackwoodsBackup/issues/8') unless full_cache_seed

--- a/app/lib/backup_engine/communicator_backend/s3.rb
+++ b/app/lib/backup_engine/communicator_backend/s3.rb
@@ -9,7 +9,7 @@ module BackupEngine
     end
 
     class S3
-      def initialize(logger:, bucket:, s3_client_config:, storage_class: 'STANDARD_IA', full_cache_seed: true)
+      def initialize(logger:, bucket:, s3_client_config:, cache_config: {}, storage_class: 'STANDARD_IA', full_cache_seed: true)
         @logger = logger
         @bucket = bucket.freeze
         @storage_class = storage_class.freeze
@@ -26,7 +26,7 @@ module BackupEngine
         # full_cache_seed argument is left for reverse compatibility in configs
         raise(S3CommunicatorError, 'full_cache_seed option has been deprecated, see https://github.com/TJNII/BackwoodsBackup/issues/8') unless full_cache_seed
 
-        @cache = S3ListCache.new do |cache|
+        @cache = S3ListCache.new(cache_config.symbolize_keys.merge(id: bucket)) do |cache|
           @logger.info('Seeding local cache of S3 object paths')
           _s3_list(path: Pathname.new('.'), cache: cache)
           @logger.info('Seeding local cache of S3 object paths complete')

--- a/app/lib/backup_engine/communicator_backend/s3.rb
+++ b/app/lib/backup_engine/communicator_backend/s3.rb
@@ -68,6 +68,7 @@ module BackupEngine
         @cache.exists?(path: path)
       end
 
+      # NOTE: This only returns the next level paths and is intended to behave like a filesystem ls call
       def list(path:)
         @cache.children(path: path).sort.map { |child| path.join(child) }
       end

--- a/app/lib/backup_engine/communicator_backend/s3.rb
+++ b/app/lib/backup_engine/communicator_backend/s3.rb
@@ -9,7 +9,8 @@ module BackupEngine
     end
 
     class S3
-      def initialize(bucket:, s3_client_config:, storage_class: 'STANDARD_IA', full_cache_seed: true)
+      def initialize(logger:, bucket:, s3_client_config:, storage_class: 'STANDARD_IA', full_cache_seed: true)
+        @logger = logger
         @bucket = bucket.freeze
         @storage_class = storage_class.freeze
 
@@ -25,8 +26,11 @@ module BackupEngine
         # full_cache_seed argument is left for reverse compatibility in configs
         raise(S3CommunicatorError, 'full_cache_seed option has been deprecated, see https://github.com/TJNII/BackwoodsBackup/issues/8') unless full_cache_seed
 
-        @cache = S3ListCache.new
-        _s3_list(path: Pathname.new('.'))
+        @cache = S3ListCache.new do |cache|
+          @logger.info('Seeding local cache of S3 object paths')
+          _s3_list(path: Pathname.new('.'), cache: cache)
+          @logger.info('Seeding local cache of S3 object paths complete')
+        end
       end
 
       def date(path:)
@@ -70,18 +74,18 @@ module BackupEngine
 
       def upload(path:, payload:)
         @s3.put_object(bucket: @bucket, key: path.to_s, body: payload, storage_class: @storage_class)
-        @cache.add(path: path, date: Time.now)
+        @cache.add(path: path, date: Time.now.to_f)
       end
 
       private
 
-      def _cache_add_s3_list_output(contents:)
+      def _cache_add_s3_list_output(contents:, cache:)
         contents.each do |object|
-          @cache.add(path: object.key, date: object.last_modified)
+          cache.add(path: object.key, date: object.last_modified.to_f)
         end
       end
 
-      def _s3_list(path:)
+      def _s3_list(path:, cache:)
         # This is a cost optimization for the BackwoodsBackup use case.
         # AWS charges per request, so it's cost effective to cast as wide a net as possible and store the results in memory
         # (hence the S3ListCache class)
@@ -93,10 +97,11 @@ module BackupEngine
 
         list_path = path_array[1..2].join('/')
         list_out = @s3.list_objects_v2(bucket: @bucket, prefix: list_path)
-        _cache_add_s3_list_output(contents: list_out.contents)
+        _cache_add_s3_list_output(contents: list_out.contents, cache: cache)
         until list_out.next_continuation_token.nil?
+          @logger.debug('Seeding local cache of S3 object paths: Continuing...')
           list_out = @s3.list_objects_v2(bucket: @bucket, continuation_token: list_out.next_continuation_token)
-          _cache_add_s3_list_output(contents: list_out.contents)
+          _cache_add_s3_list_output(contents: list_out.contents, cache: cache)
         end
       end
     end

--- a/app/lib/backup_engine/communicator_backend/s3.rb
+++ b/app/lib/backup_engine/communicator_backend/s3.rb
@@ -25,12 +25,12 @@ module BackupEngine
         # full_cache_seed argument is left for reverse compatibility in configs
         raise(S3CommunicatorError, 'full_cache_seed option has been deprecated, see https://github.com/TJNII/BackwoodsBackup/issues/8') unless full_cache_seed
 
-        @cache = S3ListCache.new(initial_date: Time.new(0))
+        @cache = S3ListCache.new
         _s3_list(path: Pathname.new('.'))
       end
 
       def date(path:)
-        @cache[path]
+        @cache.date(path: path)
       end
 
       def delete(path:)

--- a/app/lib/backup_engine/communicator_backend/s3_list_cache.rb
+++ b/app/lib/backup_engine/communicator_backend/s3_list_cache.rb
@@ -75,7 +75,7 @@ module BackupEngine
 
       def date(path:)
         ret_val = @cache[_sanitize_path(path: path).to_s]
-        return ret_val unless ret_val.nil?
+        return Time.at(ret_val) unless ret_val.nil?
 
         raise(Errno::ENOENT, "Unknown path #{path}")
       end

--- a/app/lib/backup_engine/config/config_base.rb
+++ b/app/lib/backup_engine/config/config_base.rb
@@ -28,7 +28,7 @@ module BackupEngine
       private
 
       def _parse_communicator_block(config)
-        @communicator = BackupEngine::Communicator.new(config)
+        @communicator = BackupEngine::Communicator.new(config.merge(logger: @logger))
       end
 
       def _parse_encryption_block(config)

--- a/app/lib/backup_engine/manifest.rb
+++ b/app/lib/backup_engine/manifest.rb
@@ -42,6 +42,8 @@ module BackupEngine
                             manifest: @manifest)
 
         compression_result = compression_engine.compress(payload)
+        @logger.debug("Manifest length: #{payload.length} Compressed #{compression_result.compression_percent}%")
+
         encryption_engine.encrypt(path: path,
                                   payload: compression_result.payload,
                                   metadata: {

--- a/app/lib/backup_engine/redis_hash.rb
+++ b/app/lib/backup_engine/redis_hash.rb
@@ -1,0 +1,122 @@
+require 'json'
+require 'redis'
+
+module BackupEngine
+  # This class is a wrapper around Redis Hashes with a hash-wide TTL designed to mimic Hash
+  # It stores values as JSON blobs to let the JSON library handle object serialization.
+  class RedisHash
+    include Enumerable
+
+    def initialize(redis_communicator:, redis_path:, ttl:, &block)
+      @redis = redis_communicator
+      @path = redis_path
+      @load_block = block
+      @ttl = ttl
+    end
+
+    def [](key)
+      raw_value = @redis.hget(@path, key)
+      # NOTE: Due to the JSON encoding a nil get response is equivalent to no key
+      return JSON.parse(raw_value) unless raw_value.nil?
+      return nil if @load_block.nil?
+
+      return @load_block.call(self, key)
+    end
+
+    def []=(key, value)
+      @redis.hset(@path, key, JSON.dump(value))
+      _set_ttl
+    end
+
+    def clear
+      @redis.unlink(@path)
+      return self
+    end
+
+    # WARNING: Deviation from Hash as this does not return the deleted value
+    def delete(key)
+      @redis.hdel(@path, key)
+      return nil
+    end
+
+    # WARNING: Deviation from hash: Does not support enumerator use
+    def delete_if
+      each_pair do |key, value|
+        delete(key) if yield(key, value)
+      end
+      return nil
+    end
+
+    def each_pair
+      cursor = 0
+      loop do
+        cursor, values = @redis.hscan(@path, cursor)
+        values.to_h.each_pair do |key, raw_value|
+          yield(key, JSON.parse(raw_value))
+        end
+        return if cursor.to_s == '0'
+      end
+    end
+
+    def each
+      each_pair do |key, value|
+        yield([key, value])
+      end
+    end
+
+    def empty?
+      length <= 0
+    end
+
+    def fetch(key, *args)
+      raise(ArgumentError, "wrong number of arguments (given #{args.length + 1}, expected 1..2)") if args.length > 1
+
+      raw_value = @redis.hget(@path, key)
+      return JSON.parse(raw_value) unless raw_value.nil?
+      return args[0] if args.length == 1
+
+      raise(KeyError, "key not found: #{key}")
+    end
+
+    def key?(key)
+      @redis.hexists(@path, key)
+    end
+
+    def keys
+      @redis.hkeys(@path)
+    end
+
+    def length
+      @redis.hlen(@path)
+    end
+
+    def merge!(other)
+      raw_other = other.map { |key, value| [key, JSON.dump(value)] }
+      @redis.hmset(@path, *raw_other)
+      _set_ttl
+      return self
+    end
+
+    def ttl
+      @redis.ttl(@path)
+    end
+
+    def values
+      @redis.hvals(@path).map { |value| JSON.parse(value) }
+    end
+
+    private
+
+    def _set_ttl
+      # Cache if the TTL has been confirmed already
+      # This is done to prevent a ttl call per key set, which adds ~60s/1000000keys
+      return if @ttl_ok
+
+      current_ttl = ttl
+      return if current_ttl > 0 && current_ttl < @ttl
+
+      @redis.expire(@path, @ttl)
+      @ttl_ok = true
+    end
+  end
+end

--- a/app/spec/functional/backup_engine_functional_spec.rb
+++ b/app/spec/functional/backup_engine_functional_spec.rb
@@ -20,7 +20,7 @@ describe 'Backup Engine: Functional' do
 
   before :all do
     @logger = Logger.new(STDOUT)
-    @communicator = BackupEngine::Communicator.new(type: 'filesystem', backend_config: { base_path: '/tmp/test_backup_output' })
+    @communicator = BackupEngine::Communicator.new(type: 'filesystem', backend_config: { base_path: '/tmp/test_backup_output' }, logger: @logger)
 
     @encryption_keys = {}.tap do |h|
       # TODO: Test with multiple keys

--- a/app/spec/functional/cleaner_functional_spec.rb
+++ b/app/spec/functional/cleaner_functional_spec.rb
@@ -19,7 +19,7 @@ describe 'Cleaner: Functional' do
     logger
   end
 
-  let(:communicator) { BackupEngine::Communicator.new(type: 'filesystem', backend_config: { base_path: backup_directory }) }
+  let(:communicator) { BackupEngine::Communicator.new(type: 'filesystem', backend_config: { base_path: backup_directory }, logger: logger) }
   let(:encryption_keys) do
     {
       manifest_key_1: {

--- a/app/spec/helpers/s3_mocks.rb
+++ b/app/spec/helpers/s3_mocks.rb
@@ -1,0 +1,77 @@
+module BackupEngineTestHelpers
+  # Mock S3 functions used per
+  # https://aws.amazon.com/blogs/developer/advanced-client-stubbing-in-the-aws-sdk-for-ruby-version-3/
+  # NOTE: Public methods are intended to be used in tests to query the mock state, they are not maps to S3 SDK functions
+  class S3Mocks
+    def initialize
+      @buckets = Hash.new { |h, k| h[k] = {} }
+    end
+
+    def delete_object(bucket:, key:)
+      @buckets[bucket].delete(key)
+    end
+
+    def get_object(bucket:, key:)
+      @buckets[bucket].fetch(key, {})
+    end
+
+    def object_paths(bucket:)
+      @buckets[bucket].keys
+    end
+
+    def seed_object(bucket:, key:, body:, last_modified:, storage_class:)
+      raise('Body cannot be nil') if body.nil?
+
+      @buckets[bucket][key] = {
+        body: body,
+        last_modified: last_modified,
+        storage_class: storage_class,
+        content_length: body.length
+      }
+    end
+
+    def stub_client(aws_s3_sdk_client:)
+      %i[delete_objects get_object list_objects_v2 put_object].each do |operation_name|
+        aws_s3_sdk_client.stub_responses(operation_name, ->(context) { method(:"_stub_#{operation_name}").call(context) })
+      end
+    end
+
+    private
+
+    def _stub_delete_objects(context)
+      context.params[:delete][:objects].each do |object_param|
+        raise("Attempt to delete non-existent object #{object_param[:key]}") unless @buckets[context.params[:bucket]].key?(object_param[:key])
+
+        @buckets[context.params[:bucket]].delete(object_param[:key])
+      end
+    end
+
+    def _stub_get_object(context)
+      @buckets[context.params[:bucket]].fetch(context.params[:key], 'NoSuchKey')
+    end
+
+    def _stub_list_objects_v2(context)
+      # TODO: Pagination
+      contents = @buckets[context.params[:bucket]].map do |key, object|
+        next if !context.params[:prefix].empty? && key !~ /^#{context.params[:prefix]}/
+
+        { key: key,
+          last_modified: object[:last_modified] }
+      end
+
+      return {
+        contents: contents.compact,
+        next_continuation_token: nil
+      }
+    end
+
+    def _stub_put_object(context)
+      @buckets[context.params[:bucket]][context.params[:key]] = {
+        last_modified: Time.now,
+        content_length: context.params[:body].length
+      }.merge(context.params.reject { |k, _| %i[bucket key].include?(k) })
+
+      return {}
+    end
+  end
+end

--- a/app/spec/unit/backup_engine/communicator_backend/filesystem_spec.rb
+++ b/app/spec/unit/backup_engine/communicator_backend/filesystem_spec.rb
@@ -1,0 +1,106 @@
+require 'fileutils'
+require 'securerandom'
+require_relative '../../../spec_helper.rb'
+
+require_relative '../../../../lib/backup_engine/communicator_backend/filesystem.rb'
+
+describe 'Backup Engine: unit' do
+  describe BackupEngine::CommunicatorBackend::Filesystem do
+    let(:test_base_path) do
+      path = Pathname.new('/tmp').join(SecureRandom.hex)
+      FileUtils.mkdir_p(path)
+      path
+    end
+
+    let(:test_obj) { described_class.new(base_path: test_base_path) }
+
+    after :each do
+      FileUtils.rm_rf(test_base_path)
+    end
+
+    describe '.date' do
+      it 'returns the date of the object' do
+        test_path = 'foo'
+        FileUtils.touch(test_base_path.join(test_path))
+        expect(test_obj.date(path: test_path)).to be_instance_of(Time)
+        expect(test_obj.date(path: test_path).to_f).to be_within(0.1).of(Time.now.to_f)
+      end
+    end
+
+    describe '.delete' do
+      before :each do
+        ['foo/bar/foobar',
+         'foo/bar/foobaz',
+         'foo/baz/foobar',
+         'foo/baz/foobaz'].each do |test_path|
+          FileUtils.mkdir_p(test_base_path.join(test_path))
+        end
+      end
+
+      it 'deletes paths and subpaths' do
+        test_obj.delete(path: 'foo/bar')
+        ['foo/bar/foobar', 'foo/bar/foobaz'].each do |test_path|
+          expect(File.exist?(test_base_path.join(test_path))).to be false
+        end
+
+        ['foo/baz/foobar', 'foo/baz/foobaz'].each do |test_path|
+          expect(File.exist?(test_base_path.join(test_path))).to be true
+        end
+      end
+
+      it 'Does nothing if the path does not exist' do
+        test_obj.delete(path: 'bogus/path')
+        ['foo/bar/foobar', 'foo/bar/foobaz', 'foo/baz/foobar', 'foo/baz/foobaz'].each do |test_path|
+          expect(File.exist?(test_base_path.join(test_path))).to be true
+        end
+      end
+    end
+
+    describe '.download' do
+      it 'returns the contents of an object' do
+        test_path = 'foo'
+        test_body = SecureRandom.hex
+
+        File.write(test_base_path.join(test_path), test_body)
+        expect(test_obj.download(path: test_path)).to eq(test_body)
+      end
+    end
+
+    describe '.exists?' do
+      it 'returns true if the object exists' do
+        test_path = 'foo/bar/baz'
+        FileUtils.mkdir_p(test_base_path.join(test_path))
+        expect(test_obj.exists?(path: test_path)).to eq true
+      end
+
+      it 'returns false if the object does not exist' do
+        test_path = 'foo/bar/baz'
+        expect(test_obj.exists?(path: test_path)).to eq false
+      end
+    end
+
+    describe '.list' do
+      before :each do
+        ['foo/bar/foobar',
+         'foo/bar/foobaz'].each do |test_path|
+          FileUtils.mkdir_p(test_base_path.join(test_path))
+        end
+      end
+
+      it 'returns the objects for the path' do
+        expect(test_obj.list(path: Pathname.new('foo'))).to eq(['foo/bar'].map { |p| Pathname.new(p) })
+        expect(test_obj.list(path: Pathname.new('foo/bar'))).to eq(['foo/bar/foobar', 'foo/bar/foobaz'].map { |p| Pathname.new(p) })
+      end
+    end
+
+    describe '.upload' do
+      it 'uploads content to the bucket' do
+        test_path = 'foo/bar/baz'
+        test_body = SecureRandom.hex
+        test_obj.upload(path: test_path, payload: test_body)
+
+        expect(File.read(test_base_path.join(test_path))).to eq(test_body)
+      end
+    end
+  end
+end

--- a/app/spec/unit/backup_engine/communicator_backend/s3_list_cache_spec.rb
+++ b/app/spec/unit/backup_engine/communicator_backend/s3_list_cache_spec.rb
@@ -5,175 +5,201 @@ require_relative '../../../../lib/backup_engine/communicator_backend/s3_list_cac
 
 describe 'Backup Engine: unit' do
   describe BackupEngine::CommunicatorBackend::S3ListCache do
-    let(:test_obj) { described_class.new { |_| nil } }
+    shared_examples 'cache behavior' do
+      let(:test_obj) { described_class.new(test_config) { |_| nil } }
 
-    describe 'add' do
-      it 'adds to the cache' do
-        test_obj.add(path: 'foo/bar', date: 100)
-        test_obj.add(path: 'foo/baz', date: 200)
-        test_obj.add(path: 'bar/baz', date: 300)
+      describe 'add' do
+        it 'adds to the cache' do
+          test_obj.add(path: 'foo/bar', date: 100)
+          test_obj.add(path: 'foo/baz', date: 200)
+          test_obj.add(path: 'bar/baz', date: 300)
 
-        expect(test_obj.cache['/foo/bar']).to eql(100)
-        expect(test_obj.cache['/foo/baz']).to eql(200)
-        expect(test_obj.cache['/bar/baz']).to eql(300)
-      end
+          expect(test_obj.cache['/foo/bar']).to eql(100)
+          expect(test_obj.cache['/foo/baz']).to eql(200)
+          expect(test_obj.cache['/bar/baz']).to eql(300)
+        end
 
-      it 'applies the date to all lower keys' do
-        test_obj.add(path: 'foo/bar/baz', date: 100)
-        expect(test_obj.cache['/foo/bar/baz']).to eql(100)
-        expect(test_obj.cache['/foo/bar']).to eql(100)
-        expect(test_obj.cache['/foo']).to eql(100)
-      end
+        it 'applies the date to all lower keys' do
+          test_obj.add(path: 'foo/bar/baz', date: 100)
+          expect(test_obj.cache['/foo/bar/baz']).to eql(100)
+          expect(test_obj.cache['/foo/bar']).to eql(100)
+          expect(test_obj.cache['/foo']).to eql(100)
+        end
 
-      it 'updates lower keys without discarding data' do
-        test_obj.add(path: 'foo/bar', date: 100)
-        test_obj.add(path: 'foo/baz', date: 200)
-        test_obj.add(path: 'foo', date: 300)
+        it 'updates lower keys without discarding data' do
+          test_obj.add(path: 'foo/bar', date: 100)
+          test_obj.add(path: 'foo/baz', date: 200)
+          test_obj.add(path: 'foo', date: 300)
 
-        expect(test_obj.cache['/foo/bar']).to eql(100)
-        expect(test_obj.cache['/foo/baz']).to eql(200)
-        expect(test_obj.cache['/foo']).to eql(300)
-      end
+          expect(test_obj.cache['/foo/bar']).to eql(100)
+          expect(test_obj.cache['/foo/baz']).to eql(200)
+          expect(test_obj.cache['/foo']).to eql(300)
+        end
 
-      it 'propagates the newest date down' do
-        test_obj.add(path: 'foo/bar/baz', date: 300)
-        test_obj.add(path: 'foo/bar', date: 200)
-        test_obj.add(path: 'foo', date: 100)
+        it 'propagates the newest date down' do
+          test_obj.add(path: 'foo/bar/baz', date: 300)
+          test_obj.add(path: 'foo/bar', date: 200)
+          test_obj.add(path: 'foo', date: 100)
 
-        expect(test_obj.cache['/foo/bar/baz']).to eql(300)
-        expect(test_obj.cache['/foo/bar']).to eql(300)
-        expect(test_obj.cache['/foo']).to eql(300)
-      end
-    end
-
-    describe 'cache' do
-      it 'is immutable' do
-        expect { test_obj.cache['foo'] = nil }.to raise_exception(FrozenError)
-      end
-    end
-
-    describe 'children' do
-      it 'returns the child list on empty path' do
-        test_obj.add(path: 'foo', date: 100)
-        test_obj.add(path: 'bar', date: 300)
-        test_obj.add(path: 'baz', date: 200)
-
-        expect(test_obj.children(path: '/')).to eq %w[foo bar baz]
-      end
-
-      it 'raises exception on unknown key' do
-        expect { test_obj.children(path: 'unknown/key') }.to raise_exception(Errno::ENOENT)
-      end
-
-      it 'returns nested child lists' do
-        test_obj.add(path: 'foo/bar/baz/foobar/barbaz', date: 100)
-        test_obj.add(path: 'foo/bar/baz/foobaz/barbaz', date: 100)
-        test_obj.add(path: 'bar', date: 300)
-        test_obj.add(path: 'baz', date: 200)
-
-        expect(test_obj.children(path: 'foo/bar/baz')).to eq %w[foobar foobaz]
-      end
-    end
-
-    describe '.date' do
-      it 'raises exception unknown key' do
-        expect { test_obj.date(path: 'unknown/key') }.to raise_exception(Errno::ENOENT)
-      end
-
-      it 'returns child dates' do
-        test_obj.add(path: 'foo/bar', date: 100)
-        test_obj.add(path: 'foo/baz', date: 200)
-        test_obj.add(path: 'bar/baz', date: 300)
-
-        expect(test_obj.date(path: 'foo/bar')).to eql(100)
-        expect(test_obj.date(path: 'foo/baz')).to eql(200)
-        expect(test_obj.date(path: 'bar/baz')).to eql(300)
-      end
-    end
-
-    describe 'delete' do
-      it 'empties the cache on empty path' do
-        test_obj.add(path: 'foo/bar/baz/foobar', date: 100)
-        test_obj.delete(path: '')
-        expect(test_obj.cache).to be_empty
-      end
-
-      it 'raises exception unknown key' do
-        expect { test_obj.delete(path: 'unknown/key') }.to raise_exception(Errno::ENOENT)
-      end
-
-      it 'recursively deletes child lists and empty parents' do
-        test_obj.add(path: 'foo/bar/baz/foobar', date: 100)
-        test_obj.add(path: 'foo/baz/foobar', date: 200)
-
-        test_obj.delete(path: 'foo/bar/baz')
-        expect(test_obj.cache.keys.sort).to eql %w[/ /foo /foo/baz /foo/baz/foobar]
-      end
-    end
-
-    describe 'exists?' do
-      it 'returns false on unknown key' do
-        expect(test_obj.exists?(path: 'unknown/key')).to be false
-      end
-
-      it 'returns true for known children' do
-        test_obj.add(path: 'foo/bar', date: 100)
-        test_obj.add(path: 'foo/baz', date: 200)
-        test_obj.add(path: 'bar/baz', date: 300)
-
-        expect(test_obj.exists?(path: 'foo/bar')).to be true
-        expect(test_obj.exists?(path: 'foo/baz')).to be true
-        expect(test_obj.exists?(path: 'bar/baz')).to be true
-      end
-    end
-
-    describe 'Cache Seeding' do
-      let(:seed_values) do
-        Hash.new.tap do |h|
-          h[Array.new(3) { SecureRandom.hex }.join('/')] = rand(0..1000)
+          expect(test_obj.cache['/foo/bar/baz']).to eql(300)
+          expect(test_obj.cache['/foo/bar']).to eql(300)
+          expect(test_obj.cache['/foo']).to eql(300)
         end
       end
 
-      let(:test_obj) do
-        described_class.new do |cache_obj|
-          # Test: Cache should never seed unless empty
-          raise('Attempted to seed non-empty cache') unless cache_obj.cache.empty?
+      describe 'cache' do
+        it 'is immutable' do
+          expect { test_obj.cache['foo'] = nil }.to raise_exception(FrozenError)
+        end
+      end
 
-          seed_values.each_pair do |path, date|
-            cache_obj.add(path: path, date: date)
-          end
+      describe 'children' do
+        it 'returns the child list on empty path' do
+          test_obj.add(path: 'foo', date: 100)
+          test_obj.add(path: 'bar', date: 300)
+          test_obj.add(path: 'baz', date: 200)
+
+          expect(test_obj.children(path: '/')).to eq %w[foo bar baz]
+        end
+
+        it 'raises exception on unknown key' do
+          expect { test_obj.children(path: 'unknown/key') }.to raise_exception(Errno::ENOENT)
+        end
+
+        it 'returns nested child lists' do
+          test_obj.add(path: 'foo/bar/baz/foobar/barbaz', date: 100)
+          test_obj.add(path: 'foo/bar/baz/foobaz/barbaz', date: 100)
+          test_obj.add(path: 'bar', date: 300)
+          test_obj.add(path: 'baz', date: 200)
+
+          expect(test_obj.children(path: 'foo/bar/baz')).to eq %w[foobar foobaz]
         end
       end
 
       describe '.date' do
-        it 'Seeds cold caches' do
-          seed_values.each_pair do |path, date|
-            expect(test_obj.date(path: path)).to eq date
-          end
+        it 'raises exception unknown key' do
+          expect { test_obj.date(path: 'unknown/key') }.to raise_exception(Errno::ENOENT)
         end
 
-        it 'Does not seed caches with values' do
+        it 'returns child dates' do
           test_obj.add(path: 'foo/bar', date: 100)
-          seed_values.keys.each do |path|
-            expect { test_obj.date(path: path) }.to raise_exception(Errno::ENOENT)
-          end
+          test_obj.add(path: 'foo/baz', date: 200)
+          test_obj.add(path: 'bar/baz', date: 300)
+
+          expect(test_obj.date(path: 'foo/bar')).to eql(100)
+          expect(test_obj.date(path: 'foo/baz')).to eql(200)
+          expect(test_obj.date(path: 'bar/baz')).to eql(300)
         end
       end
 
-      describe '.exists' do
-        it 'Seeds cold caches' do
-          seed_values.keys.each do |path|
-            expect(test_obj.exists?(path: path)).to eq true
+      describe 'delete' do
+        it 'empties the cache on empty path' do
+          test_obj.add(path: 'foo/bar/baz/foobar', date: 100)
+          test_obj.delete(path: '')
+          expect(test_obj.cache).to be_empty
+        end
+
+        it 'raises exception unknown key' do
+          expect { test_obj.delete(path: 'unknown/key') }.to raise_exception(Errno::ENOENT)
+        end
+
+        it 'recursively deletes child lists and empty parents' do
+          test_obj.add(path: 'foo/bar/baz/foobar', date: 100)
+          test_obj.add(path: 'foo/baz/foobar', date: 200)
+
+          test_obj.delete(path: 'foo/bar/baz')
+          expect(test_obj.cache.keys.sort).to eql %w[/ /foo /foo/baz /foo/baz/foobar]
+        end
+      end
+
+      describe 'exists?' do
+        it 'returns false on unknown key' do
+          expect(test_obj.exists?(path: 'unknown/key')).to be false
+        end
+
+        it 'returns true for known children' do
+          test_obj.add(path: 'foo/bar', date: 100)
+          test_obj.add(path: 'foo/baz', date: 200)
+          test_obj.add(path: 'bar/baz', date: 300)
+
+          expect(test_obj.exists?(path: 'foo/bar')).to be true
+          expect(test_obj.exists?(path: 'foo/baz')).to be true
+          expect(test_obj.exists?(path: 'bar/baz')).to be true
+        end
+      end
+
+      describe 'Cache Seeding' do
+        let(:seed_values) do
+          Hash.new.tap do |h|
+            h[Array.new(3) { SecureRandom.hex }.join('/')] = rand(0..1000)
           end
         end
 
-        it 'Does not seed caches with values' do
-          test_obj.add(path: 'foo/bar', date: 100)
-          seed_values.keys.each do |path|
-            expect(test_obj.exists?(path: path)).to eq false
+        let(:test_obj) do
+          described_class.new(test_config) do |cache_obj|
+            # Test: Cache should never seed unless empty
+            raise('Attempted to seed non-empty cache') unless cache_obj.cache.empty?
+
+            seed_values.each_pair do |path, date|
+              cache_obj.add(path: path, date: date)
+            end
+          end
+        end
+
+        describe '.date' do
+          it 'Seeds cold caches' do
+            seed_values.each_pair do |path, date|
+              expect(test_obj.date(path: path)).to eq date
+            end
+          end
+
+          it 'Does not seed caches with values' do
+            test_obj.add(path: 'foo/bar', date: 100)
+            seed_values.keys.each do |path|
+              expect { test_obj.date(path: path) }.to raise_exception(Errno::ENOENT)
+            end
+          end
+        end
+
+        describe '.exists' do
+          it 'Seeds cold caches' do
+            seed_values.keys.each do |path|
+              expect(test_obj.exists?(path: path)).to eq true
+            end
+          end
+
+          it 'Does not seed caches with values' do
+            test_obj.add(path: 'foo/bar', date: 100)
+            seed_values.keys.each do |path|
+              expect(test_obj.exists?(path: path)).to eq false
+            end
           end
         end
       end
+    end
+
+    describe 'in-memory store' do
+      let(:test_config) do
+        {
+          id: 's3_list_cache_spec',
+          type: 'memory',
+          ttl: 10
+        }
+      end
+
+      it_behaves_like 'cache behavior'
+    end
+
+    describe 'redis store' do
+      let(:test_config) do
+        {
+          id: "s3_list_cache_spec/#{SecureRandom.hex}",
+          type: 'redis',
+          ttl: 10
+        }
+      end
+
+      it_behaves_like 'cache behavior'
     end
   end
 end

--- a/app/spec/unit/backup_engine/communicator_backend/s3_list_cache_spec.rb
+++ b/app/spec/unit/backup_engine/communicator_backend/s3_list_cache_spec.rb
@@ -7,32 +7,42 @@ describe 'Backup Engine: unit' do
     let(:test_class) { described_class.new }
 
     describe '[]' do
-      it 'converts the path to an array and calls lookup_by_array' do
-        expect(test_class).to receive(:lookup_by_array).with(path_array: %w[foo bar baz])
-        test_class['foo/bar/baz']
-      end
-
       it 'rasies exception on absolute paths' do
         expect { test_class['/foo/bar/baz'] }.to raise_exception(BackupEngine::CommunicatorBackend::S3ListCacheError)
+      end
+
+      it 'returns the parent date on empty key' do
+        raise('Test Error: test_class date not in expected state') unless test_class.date == 0
+
+        expect(test_class['']).to eq 0
+      end
+
+      it 'returns the parent date on unknown key' do
+        raise('Test Error: test_class date not in expected state') unless test_class.date == 0
+
+        expect(test_class['unknown/key']).to eq 0
+      end
+
+      it 'returns child dates' do
+        test_class.add(path: 'foo/bar', date: 100)
+        test_class.add(path: 'foo/baz', date: 200)
+        test_class.add(path: 'bar/baz', date: 300)
+
+        expect(test_class['foo/bar']).to eql(100)
+        expect(test_class['foo/baz']).to eql(200)
+        expect(test_class['bar/baz']).to eql(300)
       end
     end
 
     describe 'add' do
-      it 'converts the path to an array and calls add_by_array' do
-        expect(test_class).to receive(:add_by_array).with(path_array: %w[foo bar baz], date: 'test_date')
-        test_class.add(path: 'foo/bar/baz', date: 'test_date')
-      end
-
       it 'rasies exception on absolute paths' do
         expect { test_class.add(path: '/foo/bar/baz', date: 'test_date') }.to raise_exception(BackupEngine::CommunicatorBackend::S3ListCacheError)
       end
-    end
 
-    describe 'add_by_array' do
       it 'adds to the cache' do
-        test_class.add_by_array(path_array: %w[foo bar], date: 100)
-        test_class.add_by_array(path_array: %w[foo baz], date: 200)
-        test_class.add_by_array(path_array: %w[bar baz], date: 300)
+        test_class.add(path: 'foo/bar', date: 100)
+        test_class.add(path: 'foo/baz', date: 200)
+        test_class.add(path: 'bar/baz', date: 300)
 
         expect(test_class.cache['foo'].cache['bar'].date).to eql(100)
         expect(test_class.cache['foo'].cache['baz'].date).to eql(200)
@@ -40,16 +50,16 @@ describe 'Backup Engine: unit' do
       end
 
       it 'applies the date to all lower keys' do
-        test_class.add_by_array(path_array: %w[foo bar baz], date: 100)
+        test_class.add(path: 'foo/bar/baz', date: 100)
         expect(test_class.cache['foo'].cache['bar'].cache['baz'].date).to eql(100)
         expect(test_class.cache['foo'].cache['bar'].date).to eql(100)
         expect(test_class.cache['foo'].date).to eql(100)
       end
 
       it 'updates lower keys without discarding data' do
-        test_class.add_by_array(path_array: %w[foo bar], date: 100)
-        test_class.add_by_array(path_array: %w[foo baz], date: 200)
-        test_class.add_by_array(path_array: %w[foo], date: 300)
+        test_class.add(path: 'foo/bar', date: 100)
+        test_class.add(path: 'foo/baz', date: 200)
+        test_class.add(path: 'foo', date: 300)
 
         expect(test_class.cache['foo'].cache['bar'].date).to eql(100)
         expect(test_class.cache['foo'].cache['baz'].date).to eql(200)
@@ -57,9 +67,9 @@ describe 'Backup Engine: unit' do
       end
 
       it 'propagates the newest date down' do
-        test_class.add_by_array(path_array: %w[foo bar baz], date: 300)
-        test_class.add_by_array(path_array: %w[foo bar], date: 200)
-        test_class.add_by_array(path_array: %w[foo], date: 100)
+        test_class.add(path: 'foo/bar/baz', date: 300)
+        test_class.add(path: 'foo/bar', date: 200)
+        test_class.add(path: 'foo', date: 100)
 
         expect(test_class.cache['foo'].cache['bar'].cache['baz'].date).to eql(300)
         expect(test_class.cache['foo'].cache['bar'].date).to eql(300)
@@ -74,122 +84,78 @@ describe 'Backup Engine: unit' do
     end
 
     describe 'children' do
-      it 'converts the path to an array and calls children_by_array' do
-        expect(test_class).to receive(:children_by_array).with(path_array: %w[foo bar baz])
-        test_class.children(path: 'foo/bar/baz')
-      end
-
       it 'rasies exception on absolute paths' do
         expect { test_class.children(path: '/foo/bar/baz') }.to raise_exception(BackupEngine::CommunicatorBackend::S3ListCacheError)
       end
-    end
 
-    describe 'children_by_array' do
-      it 'returns the child list on empty list' do
-        test_class.add_by_array(path_array: %w[foo], date: 100)
-        test_class.add_by_array(path_array: %w[bar], date: 300)
-        test_class.add_by_array(path_array: %w[baz], date: 200)
+      it 'returns the child list on empty path' do
+        test_class.add(path: 'foo', date: 100)
+        test_class.add(path: 'bar', date: 300)
+        test_class.add(path: 'baz', date: 200)
 
-        expect(test_class.children_by_array(path_array: [])).to eq %w[foo bar baz]
+        expect(test_class.children(path: '.')).to eq %w[foo bar baz]
       end
 
       it 'raises exception on unknown key' do
-        expect { test_class.children_by_array(path_array: %w[unknown key]) }.to raise_exception(Errno::ENOENT)
+        expect { test_class.children(path: 'unknown/key') }.to raise_exception(Errno::ENOENT)
       end
 
       it 'returns nested child lists' do
-        test_class.add_by_array(path_array: %w[foo bar baz foobar], date: 100)
-        test_class.add_by_array(path_array: %w[foo bar baz foobaz], date: 100)
-        test_class.add_by_array(path_array: %w[bar], date: 300)
-        test_class.add_by_array(path_array: %w[baz], date: 200)
+        test_class.add(path: 'foo/bar/baz/foobar', date: 100)
+        test_class.add(path: 'foo/bar/baz/foobaz', date: 100)
+        test_class.add(path: 'bar', date: 300)
+        test_class.add(path: 'baz', date: 200)
 
-        expect(test_class.children_by_array(path_array: %w[foo bar baz])).to eq %w[foobar foobaz]
+        expect(test_class.children(path: 'foo/bar/baz')).to eq %w[foobar foobaz]
       end
     end
 
     describe 'delete' do
-      it 'converts the path to an array and calls delete_by_array' do
-        expect(test_class).to receive(:delete_by_array).with(path_array: %w[foo bar baz])
-        test_class.delete(path: 'foo/bar/baz')
-      end
-
       it 'rasies exception on absolute paths' do
         expect { test_class.delete(path: '/foo/bar/baz') }.to raise_exception(BackupEngine::CommunicatorBackend::S3ListCacheError)
       end
-    end
 
-    describe 'delete_by_array' do
-      it 'empties the cache on empty list' do
-        test_class.add_by_array(path_array: %w[foo bar baz foobar], date: 100)
-        test_class.delete_by_array(path_array: [])
+      it 'empties the cache on empty path' do
+        test_class.add(path: 'foo/bar/baz/foobar', date: 100)
+        test_class.delete(path: '.')
         expect(test_class.cache).to be_empty
       end
 
       it 'raises exception unknown key' do
-        expect { test_class.delete_by_array(path_array: %w[unknown key]) }.to raise_exception(Errno::ENOENT)
+        expect { test_class.delete(path: 'unknown/key') }.to raise_exception(Errno::ENOENT)
       end
 
       it 'recursively deletes child lists and empty parents' do
-        test_class.add_by_array(path_array: %w[foo bar baz foobar], date: 100)
-        test_class.add_by_array(path_array: %w[foo baz foobar], date: 200)
+        test_class.add(path: 'foo/bar/baz/foobar', date: 100)
+        test_class.add(path: 'foo/baz/foobar', date: 200)
 
-        test_class.delete_by_array(path_array: %w[foo bar baz])
+        test_class.delete(path: 'foo/bar/baz')
         expect(test_class.cache['foo'].cache.keys).to eql %w[baz]
       end
     end
 
     describe 'exists?' do
-      it 'converts the path to an array and calls exists_by_array?' do
-        expect(test_class).to receive(:exists_by_array?).with(path_array: %w[foo bar baz])
-        test_class.exists?(path: 'foo/bar/baz')
-      end
-
       it 'rasies exception on absolute paths' do
         expect { test_class.exists?(path: '/foo/bar/baz') }.to raise_exception(BackupEngine::CommunicatorBackend::S3ListCacheError)
       end
-    end
 
-    describe 'exists_by_array?' do
-      it 'returns true on empty list' do
-        expect(test_class.exists_by_array?(path_array: [])).to be true
+      # TODO: _by_array artefact
+      it 'returns true on empty path' do
+        expect(test_class.exists?(path: '.')).to be true
       end
 
       it 'returns false on unknown key' do
-        expect(test_class.exists_by_array?(path_array: %w[unknown key])).to be false
+        expect(test_class.exists?(path: 'unknown/key')).to be false
       end
 
       it 'returns true for known children' do
-        test_class.add_by_array(path_array: %w[foo bar], date: 100)
-        test_class.add_by_array(path_array: %w[foo baz], date: 200)
-        test_class.add_by_array(path_array: %w[bar baz], date: 300)
+        test_class.add(path: 'foo/bar', date: 100)
+        test_class.add(path: 'foo/baz', date: 200)
+        test_class.add(path: 'bar/baz', date: 300)
 
-        expect(test_class.exists_by_array?(path_array: %w[foo bar])).to be true
-        expect(test_class.exists_by_array?(path_array: %w[foo baz])).to be true
-        expect(test_class.exists_by_array?(path_array: %w[bar baz])).to be true
-      end
-    end
-
-    describe 'lookup_by_array' do
-      it 'returns the parent date on empty list' do
-        raise('Test Error: test_class date not in expected state') unless test_class.date == 0
-
-        expect(test_class.lookup_by_array(path_array: [])).to eq 0
-      end
-
-      it 'returns the parent date on unknown key' do
-        raise('Test Error: test_class date not in expected state') unless test_class.date == 0
-
-        expect(test_class.lookup_by_array(path_array: %w[unknown key])).to eq 0
-      end
-
-      it 'returns child dates' do
-        test_class.add_by_array(path_array: %w[foo bar], date: 100)
-        test_class.add_by_array(path_array: %w[foo baz], date: 200)
-        test_class.add_by_array(path_array: %w[bar baz], date: 300)
-
-        expect(test_class.lookup_by_array(path_array: %w[foo bar])).to eql(100)
-        expect(test_class.lookup_by_array(path_array: %w[foo baz])).to eql(200)
-        expect(test_class.lookup_by_array(path_array: %w[bar baz])).to eql(300)
+        expect(test_class.exists?(path: 'foo/bar')).to be true
+        expect(test_class.exists?(path: 'foo/baz')).to be true
+        expect(test_class.exists?(path: 'bar/baz')).to be true
       end
     end
   end

--- a/app/spec/unit/backup_engine/communicator_backend/s3_list_cache_spec.rb
+++ b/app/spec/unit/backup_engine/communicator_backend/s3_list_cache_spec.rb
@@ -1,128 +1,178 @@
+require 'securerandom'
 require_relative '../../../spec_helper.rb'
 
 require_relative '../../../../lib/backup_engine/communicator_backend/s3_list_cache.rb'
 
 describe 'Backup Engine: unit' do
   describe BackupEngine::CommunicatorBackend::S3ListCache do
-    let(:test_class) { described_class.new }
+    let(:test_obj) { described_class.new { |_| nil } }
 
     describe 'add' do
       it 'adds to the cache' do
-        test_class.add(path: 'foo/bar', date: 100)
-        test_class.add(path: 'foo/baz', date: 200)
-        test_class.add(path: 'bar/baz', date: 300)
+        test_obj.add(path: 'foo/bar', date: 100)
+        test_obj.add(path: 'foo/baz', date: 200)
+        test_obj.add(path: 'bar/baz', date: 300)
 
-        expect(test_class.cache['/foo/bar']).to eql(100)
-        expect(test_class.cache['/foo/baz']).to eql(200)
-        expect(test_class.cache['/bar/baz']).to eql(300)
+        expect(test_obj.cache['/foo/bar']).to eql(100)
+        expect(test_obj.cache['/foo/baz']).to eql(200)
+        expect(test_obj.cache['/bar/baz']).to eql(300)
       end
 
       it 'applies the date to all lower keys' do
-        test_class.add(path: 'foo/bar/baz', date: 100)
-        expect(test_class.cache['/foo/bar/baz']).to eql(100)
-        expect(test_class.cache['/foo/bar']).to eql(100)
-        expect(test_class.cache['/foo']).to eql(100)
+        test_obj.add(path: 'foo/bar/baz', date: 100)
+        expect(test_obj.cache['/foo/bar/baz']).to eql(100)
+        expect(test_obj.cache['/foo/bar']).to eql(100)
+        expect(test_obj.cache['/foo']).to eql(100)
       end
 
       it 'updates lower keys without discarding data' do
-        test_class.add(path: 'foo/bar', date: 100)
-        test_class.add(path: 'foo/baz', date: 200)
-        test_class.add(path: 'foo', date: 300)
+        test_obj.add(path: 'foo/bar', date: 100)
+        test_obj.add(path: 'foo/baz', date: 200)
+        test_obj.add(path: 'foo', date: 300)
 
-        expect(test_class.cache['/foo/bar']).to eql(100)
-        expect(test_class.cache['/foo/baz']).to eql(200)
-        expect(test_class.cache['/foo']).to eql(300)
+        expect(test_obj.cache['/foo/bar']).to eql(100)
+        expect(test_obj.cache['/foo/baz']).to eql(200)
+        expect(test_obj.cache['/foo']).to eql(300)
       end
 
       it 'propagates the newest date down' do
-        test_class.add(path: 'foo/bar/baz', date: 300)
-        test_class.add(path: 'foo/bar', date: 200)
-        test_class.add(path: 'foo', date: 100)
+        test_obj.add(path: 'foo/bar/baz', date: 300)
+        test_obj.add(path: 'foo/bar', date: 200)
+        test_obj.add(path: 'foo', date: 100)
 
-        expect(test_class.cache['/foo/bar/baz']).to eql(300)
-        expect(test_class.cache['/foo/bar']).to eql(300)
-        expect(test_class.cache['/foo']).to eql(300)
+        expect(test_obj.cache['/foo/bar/baz']).to eql(300)
+        expect(test_obj.cache['/foo/bar']).to eql(300)
+        expect(test_obj.cache['/foo']).to eql(300)
       end
     end
 
     describe 'cache' do
       it 'is immutable' do
-        expect { test_class.cache['foo'] = nil }.to raise_exception(FrozenError)
+        expect { test_obj.cache['foo'] = nil }.to raise_exception(FrozenError)
       end
     end
 
     describe 'children' do
       it 'returns the child list on empty path' do
-        test_class.add(path: 'foo', date: 100)
-        test_class.add(path: 'bar', date: 300)
-        test_class.add(path: 'baz', date: 200)
+        test_obj.add(path: 'foo', date: 100)
+        test_obj.add(path: 'bar', date: 300)
+        test_obj.add(path: 'baz', date: 200)
 
-        expect(test_class.children(path: '/')).to eq %w[foo bar baz]
+        expect(test_obj.children(path: '/')).to eq %w[foo bar baz]
       end
 
       it 'raises exception on unknown key' do
-        expect { test_class.children(path: 'unknown/key') }.to raise_exception(Errno::ENOENT)
+        expect { test_obj.children(path: 'unknown/key') }.to raise_exception(Errno::ENOENT)
       end
 
       it 'returns nested child lists' do
-        test_class.add(path: 'foo/bar/baz/foobar/barbaz', date: 100)
-        test_class.add(path: 'foo/bar/baz/foobaz/barbaz', date: 100)
-        test_class.add(path: 'bar', date: 300)
-        test_class.add(path: 'baz', date: 200)
+        test_obj.add(path: 'foo/bar/baz/foobar/barbaz', date: 100)
+        test_obj.add(path: 'foo/bar/baz/foobaz/barbaz', date: 100)
+        test_obj.add(path: 'bar', date: 300)
+        test_obj.add(path: 'baz', date: 200)
 
-        expect(test_class.children(path: 'foo/bar/baz')).to eq %w[foobar foobaz]
+        expect(test_obj.children(path: 'foo/bar/baz')).to eq %w[foobar foobaz]
       end
     end
 
     describe '.date' do
       it 'raises exception unknown key' do
-        expect { test_class.date(path: 'unknown/key') }.to raise_exception(Errno::ENOENT)
+        expect { test_obj.date(path: 'unknown/key') }.to raise_exception(Errno::ENOENT)
       end
 
       it 'returns child dates' do
-        test_class.add(path: 'foo/bar', date: 100)
-        test_class.add(path: 'foo/baz', date: 200)
-        test_class.add(path: 'bar/baz', date: 300)
+        test_obj.add(path: 'foo/bar', date: 100)
+        test_obj.add(path: 'foo/baz', date: 200)
+        test_obj.add(path: 'bar/baz', date: 300)
 
-        expect(test_class.date(path: 'foo/bar')).to eql(100)
-        expect(test_class.date(path: 'foo/baz')).to eql(200)
-        expect(test_class.date(path: 'bar/baz')).to eql(300)
+        expect(test_obj.date(path: 'foo/bar')).to eql(100)
+        expect(test_obj.date(path: 'foo/baz')).to eql(200)
+        expect(test_obj.date(path: 'bar/baz')).to eql(300)
       end
     end
 
     describe 'delete' do
       it 'empties the cache on empty path' do
-        test_class.add(path: 'foo/bar/baz/foobar', date: 100)
-        test_class.delete(path: '')
-        expect(test_class.cache).to be_empty
+        test_obj.add(path: 'foo/bar/baz/foobar', date: 100)
+        test_obj.delete(path: '')
+        expect(test_obj.cache).to be_empty
       end
 
       it 'raises exception unknown key' do
-        expect { test_class.delete(path: 'unknown/key') }.to raise_exception(Errno::ENOENT)
+        expect { test_obj.delete(path: 'unknown/key') }.to raise_exception(Errno::ENOENT)
       end
 
       it 'recursively deletes child lists and empty parents' do
-        test_class.add(path: 'foo/bar/baz/foobar', date: 100)
-        test_class.add(path: 'foo/baz/foobar', date: 200)
+        test_obj.add(path: 'foo/bar/baz/foobar', date: 100)
+        test_obj.add(path: 'foo/baz/foobar', date: 200)
 
-        test_class.delete(path: 'foo/bar/baz')
-        expect(test_class.cache.keys.sort).to eql %w[/ /foo /foo/baz /foo/baz/foobar]
+        test_obj.delete(path: 'foo/bar/baz')
+        expect(test_obj.cache.keys.sort).to eql %w[/ /foo /foo/baz /foo/baz/foobar]
       end
     end
 
     describe 'exists?' do
       it 'returns false on unknown key' do
-        expect(test_class.exists?(path: 'unknown/key')).to be false
+        expect(test_obj.exists?(path: 'unknown/key')).to be false
       end
 
       it 'returns true for known children' do
-        test_class.add(path: 'foo/bar', date: 100)
-        test_class.add(path: 'foo/baz', date: 200)
-        test_class.add(path: 'bar/baz', date: 300)
+        test_obj.add(path: 'foo/bar', date: 100)
+        test_obj.add(path: 'foo/baz', date: 200)
+        test_obj.add(path: 'bar/baz', date: 300)
 
-        expect(test_class.exists?(path: 'foo/bar')).to be true
-        expect(test_class.exists?(path: 'foo/baz')).to be true
-        expect(test_class.exists?(path: 'bar/baz')).to be true
+        expect(test_obj.exists?(path: 'foo/bar')).to be true
+        expect(test_obj.exists?(path: 'foo/baz')).to be true
+        expect(test_obj.exists?(path: 'bar/baz')).to be true
+      end
+    end
+
+    describe 'Cache Seeding' do
+      let(:seed_values) do
+        Hash.new.tap do |h|
+          h[Array.new(3) { SecureRandom.hex }.join('/')] = rand(0..1000)
+        end
+      end
+
+      let(:test_obj) do
+        described_class.new do |cache_obj|
+          # Test: Cache should never seed unless empty
+          raise('Attempted to seed non-empty cache') unless cache_obj.cache.empty?
+
+          seed_values.each_pair do |path, date|
+            cache_obj.add(path: path, date: date)
+          end
+        end
+      end
+
+      describe '.date' do
+        it 'Seeds cold caches' do
+          seed_values.each_pair do |path, date|
+            expect(test_obj.date(path: path)).to eq date
+          end
+        end
+
+        it 'Does not seed caches with values' do
+          test_obj.add(path: 'foo/bar', date: 100)
+          seed_values.keys.each do |path|
+            expect { test_obj.date(path: path) }.to raise_exception(Errno::ENOENT)
+          end
+        end
+      end
+
+      describe '.exists' do
+        it 'Seeds cold caches' do
+          seed_values.keys.each do |path|
+            expect(test_obj.exists?(path: path)).to eq true
+          end
+        end
+
+        it 'Does not seed caches with values' do
+          test_obj.add(path: 'foo/bar', date: 100)
+          seed_values.keys.each do |path|
+            expect(test_obj.exists?(path: path)).to eq false
+          end
+        end
       end
     end
   end

--- a/app/spec/unit/backup_engine/communicator_backend/s3_list_cache_spec.rb
+++ b/app/spec/unit/backup_engine/communicator_backend/s3_list_cache_spec.rb
@@ -6,54 +6,22 @@ describe 'Backup Engine: unit' do
   describe BackupEngine::CommunicatorBackend::S3ListCache do
     let(:test_class) { described_class.new }
 
-    describe '[]' do
-      it 'rasies exception on absolute paths' do
-        expect { test_class['/foo/bar/baz'] }.to raise_exception(BackupEngine::CommunicatorBackend::S3ListCacheError)
-      end
-
-      it 'returns the parent date on empty key' do
-        raise('Test Error: test_class date not in expected state') unless test_class.date == 0
-
-        expect(test_class['']).to eq 0
-      end
-
-      it 'returns the parent date on unknown key' do
-        raise('Test Error: test_class date not in expected state') unless test_class.date == 0
-
-        expect(test_class['unknown/key']).to eq 0
-      end
-
-      it 'returns child dates' do
-        test_class.add(path: 'foo/bar', date: 100)
-        test_class.add(path: 'foo/baz', date: 200)
-        test_class.add(path: 'bar/baz', date: 300)
-
-        expect(test_class['foo/bar']).to eql(100)
-        expect(test_class['foo/baz']).to eql(200)
-        expect(test_class['bar/baz']).to eql(300)
-      end
-    end
-
     describe 'add' do
-      it 'rasies exception on absolute paths' do
-        expect { test_class.add(path: '/foo/bar/baz', date: 'test_date') }.to raise_exception(BackupEngine::CommunicatorBackend::S3ListCacheError)
-      end
-
       it 'adds to the cache' do
         test_class.add(path: 'foo/bar', date: 100)
         test_class.add(path: 'foo/baz', date: 200)
         test_class.add(path: 'bar/baz', date: 300)
 
-        expect(test_class.cache['foo'].cache['bar'].date).to eql(100)
-        expect(test_class.cache['foo'].cache['baz'].date).to eql(200)
-        expect(test_class.cache['bar'].cache['baz'].date).to eql(300)
+        expect(test_class.cache['/foo/bar']).to eql(100)
+        expect(test_class.cache['/foo/baz']).to eql(200)
+        expect(test_class.cache['/bar/baz']).to eql(300)
       end
 
       it 'applies the date to all lower keys' do
         test_class.add(path: 'foo/bar/baz', date: 100)
-        expect(test_class.cache['foo'].cache['bar'].cache['baz'].date).to eql(100)
-        expect(test_class.cache['foo'].cache['bar'].date).to eql(100)
-        expect(test_class.cache['foo'].date).to eql(100)
+        expect(test_class.cache['/foo/bar/baz']).to eql(100)
+        expect(test_class.cache['/foo/bar']).to eql(100)
+        expect(test_class.cache['/foo']).to eql(100)
       end
 
       it 'updates lower keys without discarding data' do
@@ -61,9 +29,9 @@ describe 'Backup Engine: unit' do
         test_class.add(path: 'foo/baz', date: 200)
         test_class.add(path: 'foo', date: 300)
 
-        expect(test_class.cache['foo'].cache['bar'].date).to eql(100)
-        expect(test_class.cache['foo'].cache['baz'].date).to eql(200)
-        expect(test_class.cache['foo'].date).to eql(300)
+        expect(test_class.cache['/foo/bar']).to eql(100)
+        expect(test_class.cache['/foo/baz']).to eql(200)
+        expect(test_class.cache['/foo']).to eql(300)
       end
 
       it 'propagates the newest date down' do
@@ -71,9 +39,9 @@ describe 'Backup Engine: unit' do
         test_class.add(path: 'foo/bar', date: 200)
         test_class.add(path: 'foo', date: 100)
 
-        expect(test_class.cache['foo'].cache['bar'].cache['baz'].date).to eql(300)
-        expect(test_class.cache['foo'].cache['bar'].date).to eql(300)
-        expect(test_class.cache['foo'].date).to eql(300)
+        expect(test_class.cache['/foo/bar/baz']).to eql(300)
+        expect(test_class.cache['/foo/bar']).to eql(300)
+        expect(test_class.cache['/foo']).to eql(300)
       end
     end
 
@@ -84,16 +52,12 @@ describe 'Backup Engine: unit' do
     end
 
     describe 'children' do
-      it 'rasies exception on absolute paths' do
-        expect { test_class.children(path: '/foo/bar/baz') }.to raise_exception(BackupEngine::CommunicatorBackend::S3ListCacheError)
-      end
-
       it 'returns the child list on empty path' do
         test_class.add(path: 'foo', date: 100)
         test_class.add(path: 'bar', date: 300)
         test_class.add(path: 'baz', date: 200)
 
-        expect(test_class.children(path: '.')).to eq %w[foo bar baz]
+        expect(test_class.children(path: '/')).to eq %w[foo bar baz]
       end
 
       it 'raises exception on unknown key' do
@@ -101,8 +65,8 @@ describe 'Backup Engine: unit' do
       end
 
       it 'returns nested child lists' do
-        test_class.add(path: 'foo/bar/baz/foobar', date: 100)
-        test_class.add(path: 'foo/bar/baz/foobaz', date: 100)
+        test_class.add(path: 'foo/bar/baz/foobar/barbaz', date: 100)
+        test_class.add(path: 'foo/bar/baz/foobaz/barbaz', date: 100)
         test_class.add(path: 'bar', date: 300)
         test_class.add(path: 'baz', date: 200)
 
@@ -110,14 +74,26 @@ describe 'Backup Engine: unit' do
       end
     end
 
-    describe 'delete' do
-      it 'rasies exception on absolute paths' do
-        expect { test_class.delete(path: '/foo/bar/baz') }.to raise_exception(BackupEngine::CommunicatorBackend::S3ListCacheError)
+    describe '.date' do
+      it 'raises exception unknown key' do
+        expect { test_class.date(path: 'unknown/key') }.to raise_exception(Errno::ENOENT)
       end
 
+      it 'returns child dates' do
+        test_class.add(path: 'foo/bar', date: 100)
+        test_class.add(path: 'foo/baz', date: 200)
+        test_class.add(path: 'bar/baz', date: 300)
+
+        expect(test_class.date(path: 'foo/bar')).to eql(100)
+        expect(test_class.date(path: 'foo/baz')).to eql(200)
+        expect(test_class.date(path: 'bar/baz')).to eql(300)
+      end
+    end
+
+    describe 'delete' do
       it 'empties the cache on empty path' do
         test_class.add(path: 'foo/bar/baz/foobar', date: 100)
-        test_class.delete(path: '.')
+        test_class.delete(path: '')
         expect(test_class.cache).to be_empty
       end
 
@@ -130,20 +106,11 @@ describe 'Backup Engine: unit' do
         test_class.add(path: 'foo/baz/foobar', date: 200)
 
         test_class.delete(path: 'foo/bar/baz')
-        expect(test_class.cache['foo'].cache.keys).to eql %w[baz]
+        expect(test_class.cache.keys.sort).to eql %w[/ /foo /foo/baz /foo/baz/foobar]
       end
     end
 
     describe 'exists?' do
-      it 'rasies exception on absolute paths' do
-        expect { test_class.exists?(path: '/foo/bar/baz') }.to raise_exception(BackupEngine::CommunicatorBackend::S3ListCacheError)
-      end
-
-      # TODO: _by_array artefact
-      it 'returns true on empty path' do
-        expect(test_class.exists?(path: '.')).to be true
-      end
-
       it 'returns false on unknown key' do
         expect(test_class.exists?(path: 'unknown/key')).to be false
       end

--- a/app/spec/unit/backup_engine/communicator_backend/s3_list_cache_spec.rb
+++ b/app/spec/unit/backup_engine/communicator_backend/s3_list_cache_spec.rb
@@ -86,9 +86,9 @@ describe 'Backup Engine: unit' do
           test_obj.add(path: 'foo/baz', date: 200)
           test_obj.add(path: 'bar/baz', date: 300)
 
-          expect(test_obj.date(path: 'foo/bar')).to eql(100)
-          expect(test_obj.date(path: 'foo/baz')).to eql(200)
-          expect(test_obj.date(path: 'bar/baz')).to eql(300)
+          expect(test_obj.date(path: 'foo/bar')).to eql(Time.at(100))
+          expect(test_obj.date(path: 'foo/baz')).to eql(Time.at(200))
+          expect(test_obj.date(path: 'bar/baz')).to eql(Time.at(300))
         end
       end
 
@@ -149,7 +149,7 @@ describe 'Backup Engine: unit' do
         describe '.date' do
           it 'Seeds cold caches' do
             seed_values.each_pair do |path, date|
-              expect(test_obj.date(path: path)).to eq date
+              expect(test_obj.date(path: path)).to eq Time.at(date)
             end
           end
 

--- a/app/spec/unit/backup_engine/communicator_backend/s3_spec.rb
+++ b/app/spec/unit/backup_engine/communicator_backend/s3_spec.rb
@@ -1,0 +1,178 @@
+require 'securerandom'
+require_relative '../../../spec_helper.rb'
+require_relative '../../../helpers/s3_mocks.rb'
+
+require_relative '../../../../lib/backup_engine/communicator_backend/s3.rb'
+
+describe 'Backup Engine: unit' do
+  describe BackupEngine::CommunicatorBackend::S3 do
+    let(:logger) { Logger.new('/dev/null') }
+    let(:bucket) { SecureRandom.hex }
+    let(:s3_client_config) { { stub_responses: true } }
+    let(:cache_config) { {} }
+    let(:storage_class) { 'STANDARD_IA' }
+    let(:full_cache_seed) { true }
+
+    let(:mock_s3) { BackupEngineTestHelpers::S3Mocks.new }
+    let(:test_obj) do
+      described_class.new(logger: logger,
+                          bucket: bucket,
+                          s3_client_config: s3_client_config,
+                          cache_config: cache_config,
+                          storage_class: storage_class,
+                          full_cache_seed: full_cache_seed).tap do |tapped_test_obj|
+        mock_s3.stub_client(aws_s3_sdk_client: tapped_test_obj.instance_variable_get(:@s3))
+      end
+    end
+
+    describe '.date' do
+      it 'returns the date of the object' do
+        test_path = 'foo/bar/baz'
+        test_date = Time.at(rand(0..1500000000))
+        mock_s3.seed_object(bucket: bucket, key: test_path, body: '', last_modified: test_date, storage_class: storage_class)
+
+        expect(test_obj.date(path: test_path)).to eq(test_date)
+      end
+
+      it 'uses cached dates' do
+        test_path = 'foo/bar/baz'
+        test_date = Time.at(rand(0..1500000000))
+
+        # Cache must have something in it otherwise it will try and seed each call
+        mock_s3.seed_object(bucket: bucket, key: '/unrelated/key', body: '', last_modified: Time.now, storage_class: storage_class)
+
+        expect { test_obj.date(path: test_path) }.to raise_exception(Errno::ENOENT)
+        mock_s3.seed_object(bucket: bucket, key: test_path, body: '', last_modified: test_date, storage_class: storage_class)
+        expect { test_obj.date(path: test_path) }.to raise_exception(Errno::ENOENT)
+      end
+    end
+
+    describe '.delete' do
+      before :each do
+        ['foo/bar/foobar',
+         'foo/bar/foobaz',
+         'foo/baz/foobar',
+         'foo/baz/foobaz'].each do |test_path|
+          mock_s3.seed_object(bucket: bucket, key: test_path, body: '', last_modified: Time.now, storage_class: storage_class)
+        end
+
+        test_obj.exists?(path: 'foo/bar') # Seed cache
+      end
+
+      it 'deletes paths and subpaths' do
+        test_obj.delete(path: 'foo/bar')
+        expect(mock_s3.object_paths(bucket: bucket)).to eq(['foo/baz/foobar', 'foo/baz/foobaz'])
+      end
+
+      it 'keeps the cache in sync' do
+        test_obj.delete(path: 'foo/bar')
+        ['foo/bar/foobar',
+         'foo/bar/foobaz'].each do |test_path|
+          expect(test_obj.exists?(path: test_path)).to eq false
+        end
+
+        ['foo/baz/foobar',
+         'foo/baz/foobaz'].each do |test_path|
+          expect(test_obj.exists?(path: test_path)).to eq true
+        end
+      end
+
+      it 'fails of the cache is out of sync' do
+        ['foo/bar/foobar',
+         'foo/bar/foobaz'].each do |test_path|
+          mock_s3.delete_object(bucket: bucket, key: test_path)
+        end
+
+        expect { test_obj.delete(path: 'foo/bar') }.to raise_exception(BackupEngine::CommunicatorBackend::S3CommunicatorError)
+      end
+
+      it 'Does nothing if the path does not exist' do
+        test_obj.delete(path: 'bogus/path')
+        expect(mock_s3.object_paths(bucket: bucket)).to eq(['foo/bar/foobar', 'foo/bar/foobaz', 'foo/baz/foobar', 'foo/baz/foobaz'])
+      end
+    end
+
+    describe '.download' do
+      it 'returns the contents of an object' do
+        test_path = 'foo/bar/baz'
+        test_body = SecureRandom.hex
+        mock_s3.seed_object(bucket: bucket, key: test_path, body: test_body, last_modified: Time.now, storage_class: storage_class)
+
+        expect(test_obj.download(path: test_path)).to eq(test_body)
+      end
+    end
+
+    describe '.exists?' do
+      it 'returns true if the object exists' do
+        test_path = 'foo/bar/baz'
+        mock_s3.seed_object(bucket: bucket, key: test_path, body: '', last_modified: Time.now, storage_class: storage_class)
+
+        expect(test_obj.exists?(path: test_path)).to eq true
+      end
+
+      it 'returns false if the object does not exist' do
+        test_path = 'foo/bar/baz'
+        expect(test_obj.exists?(path: test_path)).to eq false
+      end
+
+      it 'uses the cache' do
+        test_path = 'foo/bar/baz'
+
+        # Cache must have something in it otherwise it will try and seed each call
+        mock_s3.seed_object(bucket: bucket, key: '/unrelated/key', body: '', last_modified: Time.now, storage_class: storage_class)
+
+        expect(test_obj.exists?(path: test_path)).to eq false
+        mock_s3.seed_object(bucket: bucket, key: test_path, body: '', last_modified: Time.now, storage_class: storage_class)
+        expect(test_obj.exists?(path: test_path)).to eq false
+      end
+    end
+
+    describe '.list' do
+      before :each do
+        ['foo/bar/foobar',
+         'foo/bar/foobaz'].each do |test_path|
+          mock_s3.seed_object(bucket: bucket, key: test_path, body: '', last_modified: Time.now, storage_class: storage_class)
+        end
+      end
+
+      it 'returns the objects for the path' do
+        expect(test_obj.list(path: Pathname.new('foo'))).to eq(['foo/bar'].map { |p| Pathname.new(p) })
+        expect(test_obj.list(path: Pathname.new('foo/bar'))).to eq(['foo/bar/foobar', 'foo/bar/foobaz'].map { |p| Pathname.new(p) })
+      end
+
+      it 'uses the cache' do
+        expect(test_obj.list(path: Pathname.new('foo'))).to eq(['foo/bar'].map { |p| Pathname.new(p) })
+        mock_s3.seed_object(bucket: bucket, key: 'foo/baz', body: '', last_modified: Time.now, storage_class: storage_class)
+        expect(test_obj.list(path: Pathname.new('foo'))).to eq(['foo/bar'].map { |p| Pathname.new(p) })
+      end
+    end
+
+    describe '.upload' do
+      it 'uploads content to the bucket' do
+        test_path = 'foo/bar/baz'
+        test_body = SecureRandom.hex
+        test_obj.upload(path: test_path, payload: test_body)
+
+        expect(mock_s3.get_object(bucket: bucket, key: test_path)[:body]).to eq(test_body)
+      end
+
+      it 'Uses the correct storage class' do
+        test_path = 'foo/bar/baz'
+        test_obj.upload(path: test_path, payload: '')
+
+        expect(mock_s3.get_object(bucket: bucket, key: test_path)[:storage_class]).to eq(storage_class)
+      end
+
+      it 'Updates the cache' do
+        test_path = 'foo/bar/baz'
+
+        # Cache must have something in it otherwise it will try and seed each call
+        mock_s3.seed_object(bucket: bucket, key: '/unrelated/key', body: '', last_modified: Time.now, storage_class: storage_class)
+
+        expect(test_obj.exists?(path: test_path)).to eq false
+        test_obj.upload(path: test_path, payload: '')
+        expect(test_obj.exists?(path: test_path)).to eq true
+      end
+    end
+  end
+end

--- a/app/spec/unit/backup_engine/communicator_spec.rb
+++ b/app/spec/unit/backup_engine/communicator_spec.rb
@@ -1,0 +1,132 @@
+require 'fileutils'
+require 'securerandom'
+require_relative '../../spec_helper.rb'
+require_relative '../../helpers/s3_mocks.rb'
+
+require_relative '../../../lib/backup_engine/communicator.rb'
+
+describe 'Backup Engine: unit' do
+  describe BackupEngine::Communicator do
+    shared_examples 'common behavior' do
+      describe '.date' do
+        it 'returns the date of the object' do
+          test_path = 'foo'
+          test_obj.upload(path: test_path, metadata: '', payload: '')
+          expect(test_obj.date(path: test_path)).to be_instance_of(Time)
+          expect(test_obj.date(path: test_path).to_f).to be_within(0.1).of(Time.now.to_f)
+        end
+      end
+
+      describe '.delete' do
+        before :each do
+          ['foo/bar/foobar',
+           'foo/bar/foobaz',
+           'foo/baz/foobar',
+           'foo/baz/foobaz'].each do |test_path|
+            test_obj.upload(path: test_path, metadata: '', payload: '')
+          end
+        end
+
+        it 'deletes paths and subpaths' do
+          test_obj.delete(path: 'foo/bar')
+          ['foo/bar', 'foo/bar/foobar', 'foo/bar/foobaz'].each do |test_path|
+            expect(test_obj.exists?(path: test_path)).to eq false
+          end
+
+          ['foo/baz', 'foo/baz/foobar', 'foo/baz/foobaz'].each do |test_path|
+            expect(test_obj.exists?(path: test_path)).to eq true
+          end
+        end
+
+        it 'Does nothing if the path does not exist' do
+          test_obj.delete(path: 'bogus/path')
+          ['foo/bar/foobar', 'foo/bar/foobaz', 'foo/baz/foobar', 'foo/baz/foobaz'].each do |test_path|
+            expect(test_obj.exists?(path: test_path)).to eq true
+          end
+        end
+      end
+
+      describe '.download' do
+        it 'returns the payload and metadata fo an object' do
+          test_path = 'foo'
+          test_metadata = SecureRandom.hex
+          test_payload = SecureRandom.hex
+
+          test_obj.upload(path: test_path, metadata: test_metadata, payload: test_payload)
+          response = test_obj.download(path: test_path)
+          expect(response[:metadata]).to eq(test_metadata)
+          expect(response[:payload]).to eq(test_payload)
+        end
+
+        pending 'it raises on bad checksums when checksum verification is enabled'
+      end
+
+      describe '.exists?' do
+        it 'returns true if the object exists' do
+          test_path = 'foo/bar/baz'
+          test_obj.upload(path: test_path, metadata: '', payload: '')
+          expect(test_obj.exists?(path: test_path)).to eq true
+        end
+
+        it 'returns false if the object does not exist' do
+          test_path = 'foo/bar/baz'
+          expect(test_obj.exists?(path: test_path)).to eq false
+        end
+      end
+
+      describe '.list' do
+        before :each do
+          ['foo/bar/foobar',
+           'foo/bar/foobaz'].each do |test_path|
+            test_obj.upload(path: test_path, metadata: '', payload: '')
+          end
+        end
+
+        it 'returns the objects for the path' do
+          expect(test_obj.list(path: Pathname.new('foo'))).to eq(['foo/bar'].map { |p| Pathname.new(p) })
+          expect(test_obj.list(path: Pathname.new('foo/bar'))).to eq(['foo/bar/foobar', 'foo/bar/foobaz'].map { |p| Pathname.new(p) })
+        end
+      end
+
+      # .upload is implicitly checked as it is used to set the initial state for all the other checks
+    end
+
+    describe 'Filesystem Communicator' do
+      let(:logger) { Logger.new('/dev/null') }
+
+      let(:test_filesystem_base_path) do
+        path = Pathname.new('/tmp').join(SecureRandom.hex)
+        FileUtils.mkdir_p(path)
+        path
+      end
+
+      let(:test_obj) { described_class.new(type: 'filesystem', logger: logger, backend_config: { base_path: test_filesystem_base_path }) }
+
+      after :each do
+        FileUtils.rm_rf(test_filesystem_base_path)
+      end
+
+      it_behaves_like 'common behavior'
+    end
+
+    describe 'S3 Communicator' do
+      let(:logger) { Logger.new('/dev/null') }
+      let(:bucket) { SecureRandom.hex }
+      let(:s3_client_config) { { stub_responses: true } }
+
+      let(:mock_s3) { BackupEngineTestHelpers::S3Mocks.new }
+      let(:test_obj) do
+        described_class.new(type: 's3',
+                            logger: logger,
+                            backend_config: {
+                              bucket: bucket,
+                              s3_client_config: s3_client_config
+                            }).tap do |tapped_test_obj|
+          mock_s3.stub_client(aws_s3_sdk_client: tapped_test_obj.instance_variable_get(:@backend).instance_variable_get(:@s3))
+        end
+      end
+
+      it_behaves_like 'common behavior'
+    end
+  end
+end

--- a/app/spec/unit/backup_engine/redis_hash_spec.rb
+++ b/app/spec/unit/backup_engine/redis_hash_spec.rb
@@ -1,0 +1,284 @@
+require 'securerandom'
+require_relative '../../spec_helper.rb'
+
+require_relative '../../../lib/backup_engine/redis_hash.rb'
+
+describe 'Backup Engine: unit' do
+  describe BackupEngine::RedisHash do
+    let(:test_redis) { Redis.new }
+    let(:test_redis_path) { "BackupEngineTest/Unit/RedisHash/#{SecureRandom.hex}" }
+    let(:exemplar) { Hash.new }
+    let(:test_ttl) { 10 }
+    let(:test_obj) do
+      described_class.new(redis_communicator: test_redis,
+                          redis_path: test_redis_path,
+                          ttl: test_ttl)
+    end
+
+    before :each do
+      10.times do
+        key = SecureRandom.hex
+        value = SecureRandom.hex
+
+        exemplar[key] = value
+        test_obj[key] = value
+      end
+    end
+
+    describe '[]' do
+      describe 'without a default block' do
+        it 'returns the stored values' do
+          exemplar.keys.each do |key|
+            expect(test_obj[key]).to eq(exemplar[key])
+          end
+        end
+
+        it 'returns nil for unknown values' do
+          expect(test_obj[SecureRandom.hex]).to eq nil
+        end
+      end
+
+      describe 'with a default block' do
+        let(:dynamic_values) { Hash.new { |h, k| h[k] = SecureRandom.hex } }
+        let(:test_obj) do
+          described_class.new(redis_communicator: test_redis,
+                              redis_path: test_redis_path,
+                              ttl: test_ttl) do |h, k|
+            h[k] = dynamic_values[k]
+          end
+        end
+
+        it 'returns the stored values' do
+          exemplar.keys.each do |key|
+            expect(test_obj[key]).to eq(exemplar[key])
+          end
+        end
+
+        it 'returns the default block value on unknown keys' do
+          key = SecureRandom.hex
+          expect(test_obj[key]).to eq(dynamic_values[key])
+        end
+
+        it 'allows saving within the default block' do
+          key = SecureRandom.hex
+          test_obj[key]
+          expect(test_obj[key]).to eq(dynamic_values[key])
+        end
+
+        it 'sets the object ttl when creating a new Redis hash on unknown keys' do
+          other_test_obj = described_class.new(redis_communicator: test_redis,
+                                               redis_path: "BackupEngineTest/Unit/RedisHash/#{SecureRandom.hex}",
+                                               ttl: test_ttl) do |h, k|
+            h[k] = dynamic_values[k]
+          end
+
+          expect(other_test_obj.ttl).to be < 0
+          other_test_obj[SecureRandom.hex]
+          expect(other_test_obj.ttl).to eq(test_ttl)
+        end
+      end
+    end
+
+    describe '[]=' do
+      it 'sets values' do
+        key = SecureRandom.hex
+        value = SecureRandom.hex
+        test_obj[key] = value
+        expect(test_obj[key]).to eq(value)
+      end
+
+      it 'ensures the TTL is set' do
+        other_test_obj = described_class.new(redis_communicator: test_redis,
+                                             redis_path: "BackupEngineTest/Unit/RedisHash/#{SecureRandom.hex}",
+                                             ttl: test_ttl)
+
+        expect(other_test_obj.ttl).to be < 0
+        other_test_obj[SecureRandom.hex] = SecureRandom.hex
+        expect(other_test_obj.ttl).to eq test_ttl
+      end
+
+      it 'does not overwrite existing TTLs' do
+        key = SecureRandom.hex
+        value = SecureRandom.hex
+        test_obj[key] = value
+        expect(test_obj.ttl).to eq test_ttl
+        sleep(1)
+        expect(test_obj.ttl).to be > 0
+        expect(test_obj.ttl).to be < test_ttl
+        test_obj[key] = value
+        expect(test_obj.ttl).to be > 0
+        expect(test_obj.ttl).to be < test_ttl
+      end
+
+      it 'Resets TTLs over specified TTL' do
+        other_test_obj = described_class.new(redis_communicator: test_redis,
+                                             redis_path: test_redis_path,
+                                             ttl: test_ttl - 5)
+
+        key = SecureRandom.hex
+        value = SecureRandom.hex
+        test_obj[key] = value
+        expect(test_obj.ttl).to eq test_ttl
+        other_test_obj[key] = value
+        expect(other_test_obj.ttl).to eq(test_ttl - 5)
+      end
+    end
+
+    describe '.clear' do
+      it 'empties the hash' do
+        expect(test_obj.to_h).not_to be_empty
+        expect(test_obj.clear).to eq test_obj
+        expect(test_obj.to_h).to be_empty
+      end
+    end
+
+    describe '.delete' do
+      it 'deletes keys from the hash' do
+        key = exemplar.keys[0]
+        test_obj.delete(key)
+        expect(test_obj[key]).to eq nil
+      end
+    end
+
+    describe '.delete_if' do
+      it 'yields all key/value pairs to the block' do
+        expect { |b| test_obj.delete_if(&b) }.to yield_successive_args(*exemplar.to_a)
+      end
+
+      it 'deletes keys from the hash when the block is truthy' do
+        responses = { exemplar.keys[0] => true,
+                      exemplar.keys[1] => false,
+                      exemplar.keys[2] => nil,
+                      exemplar.keys[3] => :buttons }
+
+        test_obj.delete_if { |key, _| responses[key] }
+        exemplar.keys.each do |key|
+          expect(test_obj.key?(key)).to eq !responses[key]
+        end
+      end
+    end
+
+    describe '.empty?' do
+      it 'returns false when the hash contains data' do
+        expect(test_obj.empty?).to eq false
+      end
+
+      it 'returns true when the hash is empty' do
+        other_test_obj = described_class.new(redis_communicator: test_redis,
+                                             redis_path: "BackupEngineTest/Unit/RedisHash/#{SecureRandom.hex}",
+                                             ttl: test_ttl)
+
+        expect(other_test_obj.empty?).to eq true
+      end
+    end
+
+    describe '.fetch' do
+      describe 'with one argument' do
+        it 'returns the stored values' do
+          exemplar.keys.each do |key|
+            expect(test_obj.fetch(key)).to eq(exemplar[key])
+          end
+        end
+
+        it 'raises KeyError for unknown values' do
+          expect { test_obj.fetch(SecureRandom.hex) }.to raise_exception(KeyError)
+        end
+      end
+
+      describe 'with two arguments' do
+        it 'returns the stored values' do
+          exemplar.keys.each do |key|
+            expect(test_obj.fetch(key, :default)).to eq(exemplar[key])
+          end
+        end
+
+        it 'returns the second argument for unknown values' do
+          expect(test_obj.fetch(SecureRandom.hex, :default)).to eq :default
+        end
+      end
+    end
+
+    describe '.key?' do
+      it 'returns true for known keys' do
+        expect(test_obj.key?(exemplar.keys[0])).to eq true
+      end
+
+      it 'returns falsefor unknown keys' do
+        expect(test_obj.key?(SecureRandom.hex)).to eq false
+      end
+    end
+
+    describe '.keys' do
+      it 'behaves like Hash #keys' do
+        expect(test_obj.keys).to eq(exemplar.keys)
+      end
+    end
+
+    describe '.length' do
+      it 'returns the hash length' do
+        expect(test_obj.length).to eq(exemplar.length)
+      end
+    end
+
+    describe '.merge!' do
+      let(:other_values) { Array.new(10) { |_| [SecureRandom.hex, SecureRandom.hex] }.to_h.freeze }
+
+      it 'sets values' do
+        expect(test_obj.merge!(other_values)).to eq test_obj
+        expect(test_obj.to_h).to eq(exemplar.merge(other_values))
+      end
+
+      it 'ensures the TTL is set' do
+        other_test_obj = described_class.new(redis_communicator: test_redis,
+                                             redis_path: "BackupEngineTest/Unit/RedisHash/#{SecureRandom.hex}",
+                                             ttl: test_ttl)
+
+        expect(other_test_obj.ttl).to be < 0
+        other_test_obj.merge!(other_values)
+        expect(other_test_obj.ttl).to eq test_ttl
+      end
+
+      it 'does not overwrite existing TTLs' do
+        test_obj.merge!(other_values)
+        expect(test_obj.ttl).to eq test_ttl
+        sleep(1)
+        expect(test_obj.ttl).to be > 0
+        expect(test_obj.ttl).to be < test_ttl
+        test_obj.merge!(other_values)
+        expect(test_obj.ttl).to be > 0
+        expect(test_obj.ttl).to be < test_ttl
+      end
+
+      it 'Resets TTLs over specified TTL' do
+        other_test_obj = described_class.new(redis_communicator: test_redis,
+                                             redis_path: test_redis_path,
+                                             ttl: test_ttl - 5)
+
+        key = SecureRandom.hex
+        value = SecureRandom.hex
+        test_obj[key] = value
+        expect(test_obj.ttl).to eq test_ttl
+        other_test_obj[key] = value
+        expect(other_test_obj.ttl).to eq(test_ttl - 5)
+      end
+    end
+
+    describe '.ttl' do
+      it 'returns the TTL remaining' do
+        expect(test_obj.ttl).to eq(test_ttl)
+      end
+    end
+
+    describe '.to_h' do
+      it 'returns the hash as a Hash' do
+        expect(test_obj.to_h).to eq(exemplar)
+      end
+    end
+
+    describe '.values' do
+      it 'behaves like Hash #values' do
+        expect(test_obj.values).to eq(exemplar.values)
+      end
+    end
+  end
+end

--- a/rspec.test.yml
+++ b/rspec.test.yml
@@ -1,8 +1,15 @@
 # https://docs.docker.com/docker-hub/builds/automated-testing/
 version: '2.1'
 services:
+  redis:
+    image: redis
+
   sut:
     build: .
     tmpfs:
       - /ramdisk:size=1G
+    links:
+      - redis:redis
+    environment:
+      REDIS_URL: redis://redis
     command: bundle exec rspec --fail-fast -fd


### PR DESCRIPTION
This PR:
- Refactors how the S3 path cache is handled
- Adds persistent S3 path caching in Redis
- Removes full_cache_seed option
- Improves test coverage
- Adds a changelog

Resolves #8 